### PR TITLE
INT-35: go-cli to print dad jokes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module dadjoke
+
+go 1.16

--- a/main.go
+++ b/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+type Joke struct {
+	Joke string `json:"joke"`
+}
+
+func main() {
+	resp, err := http.Get("https://icanhazdadjoke.com/")
+	if err != nil {
+		fmt.Println("Error fetching joke:", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println("Error reading response:", err)
+		return
+	}
+
+	var joke Joke
+	err = json.Unmarshal(body, &joke)
+	if err != nil {
+		fmt.Println("Error parsing joke:", err)
+		return
+	}
+
+	fmt.Println(joke.Joke)
+}


### PR DESCRIPTION
Automated changes for INT-35

Ticket: INT-35

Description:
h2. 🎫 Create Go CLI App: Dad Jokes

h3. *Description*

This ticket outlines the development of a *command-line interface (CLI) application* written in *Golang* that provides users with a random dad joke when invoked. The primary goal is to deliver a simple, fun, and easy-to-use utility.

h3. *Functionality*

* When the CLI application is executed (e.g., {{dadjoke}} or {{go run main.go}}), it should *fetch a random dad joke*.
* The fetched joke should then be *printed to the console* in plain text.
* The application should handle network errors and API unavailability gracefully, providing a user-friendly error message instead of crashing.

h3. *Technical Stack & Details*

* *Primary Language:* *Go (Golang)*.
* *External API:* The application will consume a public *Dad Joke API* (e.g., {{icanhazdadjoke.com}} or similar). Research and select a reliable, free API.
* *HTTP Client:* Utilize Go's standard library {{net/http}} package for making API requests.
* *JSON Handling:* Use Go's standard library {{encoding/json}} package to parse the API response.
* *CLI Framework (Recommended):* Consider using a Go CLI framework like *Cobra* or *urfave/cli* for robust command-line argument parsing and structure, although for a single command, basic {{flag}} package usage might suffice initially.
* *Error Handling:* Implement {{try-catch}} equivalent logic to manage potential HTTP request failures, JSON decoding errors, or network timeouts.

h3. *Acceptance Criteria*

* The application successfully fetches and displays a dad joke.
* Error messages are clear and informative.
* The application is runnable from the command line.