### PR TITLE
INT-37: refactoring to make it a generic client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
-module dadjoke
+module dobby
 
 go 1.16
+
+require github.com/spf13/cobra v1.2.1

--- a/main.go
+++ b/main.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
+
+	"github.com/spf13/cobra"
 )
 
 type Joke struct {
@@ -39,11 +42,31 @@ func getJoke() (string, error) {
 	return joke.Joke, nil
 }
 
-func main() {
-	joke, err := getJoke()
-	if err != nil {
-		fmt.Println("Error:", err)
-		return
+func dadJokeCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "dadjoke",
+		Short: "Get a random dad joke",
+		Run: func(cmd *cobra.Command, args []string) {
+			joke, err := getJoke()
+			if err != nil {
+				fmt.Println("Error:", err)
+				return
+			}
+			fmt.Println(joke)
+		},
 	}
-	fmt.Println(joke)
+}
+
+func main() {
+	rootCmd := &cobra.Command{
+		Use:   "dobby",
+		Short: "Dobby is a helper CLI app",
+	}
+
+	rootCmd.AddCommand(dadJokeCmd())
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
Automated changes for INT-37

Ticket: INT-37

Description:
refactor this code so we can add multiple cli commands in this app , make the root command called {{dobby}} more like a sidekick / helper cli app, that can take in sub commands like dadjoke in future other apps like news etc to be extensible as a helper app